### PR TITLE
Fix backward compatibility issue with ports

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolNode.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolNode.java
@@ -68,7 +68,12 @@ public class NodePoolNode extends ZooKeeperObject {
     }
 
     public Integer getPort() {
-        return ((Double) data.get("connection_port")).intValue();
+        Double port = (Double)data.get("connection_port");
+        if (port == null) {
+            // fall back to the field name used on older NodePool clusters.
+            port = (Double)data.getOrDefault("ssh_port", 22.0);
+        }
+        return port.intValue();
     }
 
     public String getHostKey() {

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolNodeTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolNodeTest.java
@@ -137,6 +137,26 @@ public class NodePoolNodeTest {
     }
 
     /**
+     * Test backward compatibility with older NodePool clusters
+     */
+    @Test
+    public void testGetPortBackwardCompat() {
+        npn.data.remove("connection_port");
+        npn.data.put("ssh_port", 2222.0);
+
+        assertEquals(new Integer(2222), npn.getPort());
+    }
+
+    /**
+     * Test the default to 22 if no port is provided.
+     */
+    @Test
+    public void testDefaultPort() {
+        npn.data.remove("connection_port");
+        assertEquals(new Integer(22), npn.getPort());
+    }
+
+    /**
      * Test of getHostKey method, of class NodePoolNode.
      */
     @Test


### PR DESCRIPTION
Older versions NodePool clusters used "ssh_port" when persisting a Node
description to ZooKeeper, but newer versions (after git commit
d81c3524) use "connection_port".  Handle backward compatiblity
gracefully.

RE-1391