### PR TITLE
RE-1393 Allow selection of IP Family

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
@@ -154,6 +154,12 @@ public class NodePool implements Describable<NodePool> {
     private String zooKeeperRoot;
 
     /**
+     * IP Version used when SSHing to instances This value is used as a key to
+     * retrieve an instance's ip from the JSON data for an allocated node.
+     */
+    private String ipVersion;
+
+    /**
      * Constructor invoked by Jenkins's Stapler library.
      *
      * @param connectionString ZooKeeper connection string
@@ -167,11 +173,12 @@ public class NodePool implements Describable<NodePool> {
      */
     @DataBoundConstructor
     public NodePool(String connectionString,
-            String credentialsId, String labelPrefix, String requestRoot,
+            String credentialsId, String labelPrefix, String ipVersion, String requestRoot,
             String priority, String requestor, String zooKeeperRoot,
             String nodeRoot) {
         this.connectionString = connectionString;
         this.credentialsId = credentialsId;
+        this.ipVersion = ipVersion;
         this.requestRoot = requestRoot;
         this.priority = priority;
         this.requestor = requestor;
@@ -281,8 +288,12 @@ public class NodePool implements Describable<NodePool> {
         return requests;
     }
 
-    public final String getZooKeeperRoot() {
+    public String getZooKeeperRoot() {
         return zooKeeperRoot;
+    }
+
+    public String getIpVersion() {
+        return ipVersion;
     }
 
     /**
@@ -333,6 +344,10 @@ public class NodePool implements Describable<NodePool> {
 
     public void setZooKeeperRoot(String zooKeeperRoot) {
         this.zooKeeperRoot = zooKeeperRoot;
+    }
+
+    public void setIpVersion(String ipVersion) {
+        this.ipVersion = ipVersion;
     }
 
     private void initTransients() {
@@ -510,6 +525,21 @@ public class NodePool implements Describable<NodePool> {
                             SSHAuthenticator.matcher(Connection.class)
                     )
                     .includeCurrentValue(credentialsId);
+        }
+
+        public ListBoxModel doFillIpVersionItems(@QueryParameter String ipVersion) {
+            ListBoxModel items = new ListBoxModel();
+            if (ipVersion == null || ipVersion.equals("")) {
+                ipVersion = "public_ipv4";
+            }
+            final String currentIpVersion = ipVersion;
+            items.add("IPv4", "public_ipv4");
+            items.add("IPv6", "public_ipv6");
+            items.add("Use cloud provider's preferred interface", "interface_ip");
+            items.forEach((item) -> {
+                item.selected = item.value.equals(currentIpVersion);
+            });
+            return items;
         }
 
         @Override

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/config.jelly
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/config.jelly
@@ -12,6 +12,9 @@
         <f:entry title="Instance Credentials" field="credentialsId">
             <c:select/>
         </f:entry>
+        <f:entry name="ipVersion" title="SSH IP version" field="ipVersion">
+            <f:select />
+        </f:entry>
         <f:entry title="Label Prefix" field="labelPrefix">
             <f:textbox default="nodepool-"></f:textbox>
         </f:entry>

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-ipVersion.html
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-ipVersion.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    This determines the address type used to SSH to instances.
+    Can be one of public_ipv4, public_ipv6 or interface_ip. Interface ip may
+    could be either address family and depends on nodepool and
+    upstream cloud configuration. Note that instances must be configured
+    to have the appropriate address type and there must be connectivity
+    from the jenkins master to the instance via that address type.
+</div>

--- a/src/test/java/com/rackspace/jenkins_nodepool/Mocks.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/Mocks.java
@@ -59,6 +59,7 @@ public class Mocks {
     Label label;
     String labelPrefix;
     String nodeRoot;
+    String ipVersion;
     NodePool np;
     String npID;
     String npLabel;
@@ -80,6 +81,7 @@ public class Mocks {
     List<NodePoolNode> allocatedNodes;
 
     public Mocks() {
+        ipVersion = "public_ipv4";
         requestor = "unittests";
         priority = "001";
         labelPrefix = "nodepool-";
@@ -112,6 +114,7 @@ public class Mocks {
         when(nps.getLabelString()).thenReturn(label.getDisplayName());
         when(nps.getNodeName()).thenReturn(npcName);
         when(queueItem.getAssignedLabel()).thenReturn(label);
+        when(np.getIpVersion()).thenReturn(ipVersion);
         when(np.getConn()).thenReturn(conn);
         when(np.getRequestor()).thenReturn(requestor);
         when(np.getCharset()).thenReturn(charset);

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolTest.java
@@ -75,6 +75,7 @@ public class NodePoolTest {
                 m.connectionString,
                 m.credentialsID,
                 m.labelPrefix,
+                m.ipVersion,
                 m.requestRoot,
                 m.priority,
                 m.requestor,

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolsPersistenceTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolsPersistenceTest.java
@@ -25,7 +25,6 @@ package com.rackspace.jenkins_nodepool;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
-import java.util.List;
 import jenkins.model.Jenkins;
 import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
@@ -46,19 +45,27 @@ public class NodePoolsPersistenceTest {
     public void testConfigWithRestart() {
         String connectionString = "localhost:2181";
         String labelPrefix = "testprefix";
+        String ipVersion = "public_ipv6";
         rr.then(r -> {
             Jenkins j = r.getInstance();
-            NodePools nps = new NodePools();
-            List<NodePool> npsList = nps.getNodePools();
+            NodePools nps = NodePools.get();
             HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
             HtmlTextInput connectionStringBox = config.getInputByName("_.connectionString");
             HtmlTextInput labelPrefixStringBox = config.getInputByName("_.labelPrefix");
             connectionStringBox.setText(connectionString);
             labelPrefixStringBox.setText(labelPrefix);
             r.submit(config);
-
+            NodePool np = nps.getNodePools().get(0);
+            assertEquals("public_ipv4", np.getIpVersion());
+            np.setIpVersion(ipVersion);
+            nps.save();
         });
         rr.then(r -> {
+            Jenkins j = r.getInstance();
+            NodePools nps = NodePools.get();
+            NodePool np = nps.getNodePools().get(0);
+            assertEquals(ipVersion, np.getIpVersion());
+
             HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
             HtmlTextInput connectionStringBox = config.getInputByName("_.connectionString");
             HtmlTextInput labelPrefixStringBox = config.getInputByName("_.labelPrefix");


### PR DESCRIPTION
This commit adds a config option for ip family for connecting to
nodepool instances. This allows a user to avoid using instances
ipv6 addresses if their Jenkins master doesn't have ipv6 connectivity.