### PR TITLE
Add ability to hold a node for debugging

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolSlave.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolSlave.java
@@ -23,9 +23,8 @@
  */
 package com.rackspace.jenkins_nodepool;
 
-import hudson.model.Computer;
-import hudson.model.Descriptor;
-import hudson.model.Slave;
+import hudson.Extension;
+import hudson.model.*;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.plugins.sshslaves.verifiers.ManuallyProvidedKeyVerificationStrategy;
 import hudson.slaves.RetentionStrategy;
@@ -33,7 +32,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import hudson.util.RunList;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Representation of a Jenkins slave sourced from NodePool.
@@ -46,11 +50,17 @@ public class NodePoolSlave extends Slave {
      * Class logger
      */
     private static final Logger LOG = Logger.getLogger(NodePoolSlave.class.getName());
+    private static final String FORCE_HOLD_PROPERTY = "nodepool.slave.forcehold";
 
     /**
      * The node from the associated NodePool cluster.
      */
     private transient final NodePoolNode nodePoolNode;
+
+    /**
+     * Whether to continue to hold this node after the job is completed.
+     */
+    private boolean held = false;
 
     /**
      * Increment this when modifying this class.
@@ -61,10 +71,11 @@ public class NodePoolSlave extends Slave {
      * Create a new slave
      *
      * @param nodePoolNode  the node from NodePool
-     * @param credentialsId  the Jenkins credential identifier
-     * @throws Descriptor.FormException  on configuration exception
-     * @throws IOException on configuration exception
+     * @param credentialsId the Jenkins credential identifier
+     * @throws Descriptor.FormException on configuration exception
+     * @throws IOException              on configuration exception
      */
+    @DataBoundConstructor  // not used, but it makes stapler happy if you click "Save" while editing a Node.
     public NodePoolSlave(NodePoolNode nodePoolNode, String credentialsId) throws Descriptor.FormException, IOException {
 
         super(
@@ -108,11 +119,136 @@ public class NodePoolSlave extends Slave {
         Jenkins.getInstance().removeNode(this);
     }
 
-    // TODO seems odd storing the computer object on the node since it's related to the slave object here.
     @Override
     public Computer createComputer() {
         NodePoolComputer npc = new NodePoolComputer(this, nodePoolNode);
         return npc;
     }
+
+    /**
+     * This gets invoked when the user clicks "Save" while editing the "Node" in the UI.
+     * @param req  stapler request
+     * @param form form data to update slave with
+     * @return new slave object
+     * @throws Descriptor.FormException  if things go sideways
+     */
+    @Override
+    public Node reconfigure(final StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+        // update `this` with submitted data from the form and return it.  the superclass version in Node creates a new
+        // slave object, which we don't need.
+        if (form==null) {
+            return null;
+        }
+
+        final boolean held = form.getBoolean("held");
+        setHeld(held);
+
+        return this;
+    }
+
+    /**
+     * If true, hold onto the node after the associated build is completed.  Do not release it to NodePool to get
+     * cleaned up.
+     *
+     * @return true if node should be held.
+     */
+    public boolean isHeld() {
+        // check for optional "force hold" property, primarily useful for debugging.
+        final String forceHoldStr = System.getProperty(FORCE_HOLD_PROPERTY, "false");
+        final boolean forceHold = Boolean.valueOf(forceHoldStr);
+
+        return held || forceHold;
+    }
+
+    /**
+     * Set to true in order to hold the node after the build is completed.
+     *
+     * @param held whether to hold the node after the build completes
+     */
+    public void setHeld(boolean held) {
+        this.held = held;
+    }
+
+    @Override
+    public SlaveDescriptor getDescriptor() {
+        final NodePoolSlaveDescriptor descriptor = new NodePoolSlaveDescriptor();
+        descriptor.setNodePoolSlave(this);
+        return descriptor;
+    }
+
+    /**
+     * Test if the slave's build is done.
+     *
+     * @return true if the build associated with this slave has completed.
+     */
+    boolean isBuildComplete() {
+
+        final NodePoolComputer computer = (NodePoolComputer) toComputer();
+        if (computer == null) {
+            return false;
+        }
+        final RunList builds = computer.getBuilds();
+        if (builds == null || !builds.iterator().hasNext()) {
+            // unused
+            return false;
+        }
+        final Run build = (Run)builds.iterator().next();
+        if (build.isBuilding()) {
+            // a build is still in-progress
+            return false;
+        }
+
+        // a build has completed, if any executor is idle, we can safely assume it's done and the slave should be
+        // reaped
+        for (final Executor executor : computer.getAllExecutors()) {
+
+            if (executor.isIdle()) {
+                LOG.log(Level.FINE, "Executor " + executor + " of slave " + this
+                        + " has been used before.");
+                return true;
+            }
+        }
+
+        // if we reach this point, no executor has returned to idle status (yet).
+        LOG.log(Level.FINE, "Slave " + this + " does not yet have an idle executor.");
+        return false;
+    }
+
+
+    /**
+     * It makes jelly rendering on the node configuration page happy to have this defined.
+     *
+     * One thing this is used for is locating the help file associated with the form field(s).
+     */
+    @Extension
+    public static final class NodePoolSlaveDescriptor extends SlaveDescriptor {
+
+        private NodePoolSlave nodePoolSlave;
+
+        public void setNodePoolSlave(NodePoolSlave slave) {
+            this.nodePoolSlave = slave;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "NodePool Agent";
+        }
+
+        @Override
+        public boolean isInstantiable() {
+            return false;
+        }
+
+        /**
+         * If the build associated with the node/slave has completed, we don't
+         * allow toggling of the hold state.
+         *
+         * @return true if the hold checkbox on the config screen should be read-only.
+         */
+        public boolean getHoldReadOnly() {
+            return nodePoolSlave.isBuildComplete();
+        }
+    }
+
 
 }

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePoolSlave/configure-entries.jelly
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePoolSlave/configure-entries.jelly
@@ -1,0 +1,40 @@
+<!--
+  Config page
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+    NodePool agents/slaves are ephemeral and last for the duration of a single build.
+
+    <f:entry title="${%Hold Node?}" field="held">
+        <f:checkbox readonly="${descriptor.holdReadOnly}"/>
+    </f:entry>
+
+    <f:section title="Connectivity">
+
+        <f:block>
+            <p><b>IP address:</b> ${it.nodePoolNode.host}</p>
+            <p><b>Port:</b> ${it.nodePoolNode.port}</p>
+        </f:block>
+    </f:section>
+
+    <f:section title="Labels">
+
+        <f:block>
+            <p><b>Jenkins label:</b> ${it.nodePoolNode.jenkinsLabel}</p>
+            <p><b>NodePool label:</b> ${it.nodePoolNode.nPType}</p>
+        </f:block>
+
+    </f:section>
+
+    <f:section title="ZooKeeper">
+        <f:block>
+            <p><b>NodePool connection string: </b> ${it.nodePoolNode.nodePool.connectionString}</p>
+            <p><b>ZooKeeper Path:</b> /nodepool${it.nodePoolNode.path}</p>
+            <p><b>ZooKeeper ID:</b> ${it.nodePoolNode.zKID}</p>
+        </f:block>
+    </f:section>
+
+
+</j:jelly>

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePoolSlave/help-held.html
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePoolSlave/help-held.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    If true, Jenkins will continue to hold onto this NodePool slave, even after its associated build
+    is completed.
+
+    Once a build is completed, the hold status cannot be modified.  The slave can only be manually deleted.
+</div>

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolComputerTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolComputerTest.java
@@ -24,11 +24,16 @@
 package com.rackspace.jenkins_nodepool;
 
 import static org.junit.Assert.assertEquals;
+
+import hudson.model.Executor;
+import hudson.model.Queue;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import static org.mockito.Mockito.verify;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
 
 /**
  *
@@ -63,6 +68,63 @@ public class NodePoolComputerTest {
     @Test
     public void testToString() {
         assertEquals(m.npcName, m.npn.getName());
+    }
+
+    /**
+     * Test the default case where after a build executes, the computer is disabled and deleted.
+     */
+    @Test
+    public void testCleanupDelete() {
+
+        npc = spy(npc);
+        when(npc.getNode()).thenReturn(m.nps);
+
+        final Executor executor = mock(Executor.class);
+        when(executor.getOwner()).thenReturn(npc);
+
+        final Queue.Executable executable = mock(Queue.Executable.class);
+        when(executor.getCurrentExecutable()).thenReturn(executable);
+        when(executable.toString()).thenReturn("dummy_task #1");
+
+        when(m.nps.isHeld()).thenReturn(false);  // !held means computer should be deleted
+
+        final Queue.Task task = mock(Queue.Task.class);
+        npc.taskCompleted(executor, task, 0);
+
+        // confirm executor gets disabled
+        verify(npc).setAcceptingTasks(false);
+
+        // confirm the delete path was taken
+        verify(npc).deleteNodePoolComputer(npc, task);
+    }
+
+    @Test
+    public void testCleanupHeld() {
+        final Executor executor = mock(Executor.class);
+        when(executor.getOwner()).thenReturn(m.npc);
+
+        final Queue.Executable executable = mock(Queue.Executable.class);
+        when(executor.getCurrentExecutable()).thenReturn(executable);
+        when(executable.toString()).thenReturn("dummy_task #1");
+
+        when(m.nps.isHeld()).thenReturn(true); // the mock slave node is being "held"
+        when(m.npc.getNode()).thenReturn(m.nps);
+        final Queue.Task task = mock(Queue.Task.class);
+        when(task.getFullDisplayName()).thenReturn("dummy_task");
+
+        when(m.npc.getNodePoolNode()).thenReturn(m.npn);
+
+        npc.taskCompleted(executor, task, 0);
+
+        // confirm executor gets disabled
+        verify(m.npc).setAcceptingTasks(false);
+
+        try {
+            verify(m.npc.getNodePoolNode()).hold("dummy_task #1");
+        } catch (Exception e) {
+            // signature of hold() forces this catch, but we want to see any exceptions.
+            throw new RuntimeException(e);
+        }
     }
 
 }


### PR DESCRIPTION
Add the ability to hold a node for debugging.  A node in the "hold"
state will be retained by NodePool until it is deleted manually.

A node can be held by clicking the checkbox on the following UI page:

"Manage Jenkins" => "Manage Nodes" => Click the gear icon on the
node to be held.