### PR TITLE
RE-1429 Increase KazooLock acquire timeout

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/KazooLock.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/KazooLock.java
@@ -105,7 +105,7 @@ public class KazooLock {
      * @param nodePool  node pool object containing ZooKeeper connection information
      */
     public KazooLock(String path, NodePool nodePool) {
-        this(path, 5, TimeUnit.SECONDS, nodePool);
+        this(path, 600, TimeUnit.SECONDS, nodePool);
     }
 
     /**


### PR DESCRIPTION
5s is low enough that slow processing can cause transient failures
even when there aren't other contenders.

Increase to 10 minutes.