### PR TITLE
Lock nodes prior to marking in-use

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolNode.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolNode.java
@@ -143,8 +143,8 @@ public class NodePoolNode extends ZooKeeperObject {
     }
 
     public void setInUse() throws Exception {
-        setState("in-use");
         lock.acquire();
+        setState("in-use");
     }
 
     /**


### PR DESCRIPTION
When accepting nodes, lock them prior to setting their state as
"in-use".  This stops a race with the delete worker on the NodePool
launcher daemon.

RE-1451