### PR TITLE
Add retries for node requests

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolException.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolException.java
@@ -33,6 +33,8 @@ public class NodePoolException extends Exception {
     public NodePoolException(String message) {
         super(message);
     }
-    
-    
+
+    public NodePoolException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJob.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJob.java
@@ -1,0 +1,110 @@
+package com.rackspace.jenkins_nodepool;
+
+import hudson.model.Label;
+import hudson.model.Queue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wrap a Jenkins task so we can track some information over the NodePool processing cycle.
+ */
+public class NodePoolJob {
+
+    private Label label; // jenkins label
+    private final Queue.Task task;
+    private long taskId;
+
+    private List<Attempt> attempts = new ArrayList<Attempt>();  // attempts to provision
+
+    NodePoolJob(Label label, Queue.Task task, long taskId) {
+        this.label = label;
+        this.task = task;
+    }
+
+    Label getLabel() {
+        return this.label;
+    }
+
+    Queue.Task getTask() {
+        return this.task;
+    }
+
+    long getTaskId() { return this.taskId; }
+
+    void addAttempt(NodeRequest request) {
+        attempts.add(new Attempt(request));
+    }
+
+    void failAttempt(Exception e) {
+        // mark current attempt as a failure
+        getCurrentAttempt().fail(e);
+    }
+
+    void succeed() {
+        getCurrentAttempt().succeed();
+    }
+
+    private Attempt getCurrentAttempt() {
+        final int sz = attempts.size();
+        return attempts.get(sz-1);
+    }
+
+    public List<Attempt> getAttempts() { return attempts; }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (!(obj instanceof NodePoolJob)) {
+            return false;
+        }
+
+        final NodePoolJob job = (NodePoolJob) obj;
+        return job.getTaskId() == taskId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(taskId);
+    }
+
+
+    static class Attempt {
+        final NodeRequest request;
+        Exception e;
+
+        long startTime;
+        long finishTime;
+
+        Attempt(NodeRequest request) {
+            this.request = request;
+
+            this.startTime = System.currentTimeMillis();
+        }
+
+        void fail(Exception e) {
+            this.e = e;
+            setFinishTime();
+        }
+
+        void succeed() {
+            setFinishTime();
+        }
+
+        void setFinishTime() {
+            this.finishTime = System.currentTimeMillis();
+        }
+
+        long getDurationSeconds() {
+            return finishTime - startTime;
+        }
+
+        public boolean isDone() {
+            return finishTime != 0L;
+        }
+
+        public boolean isSuccess() {
+            return isDone() && e == null;
+        }
+    }
+}

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueListener.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueListener.java
@@ -78,7 +78,7 @@ public class NodePoolQueueListener extends QueueListener {
 
         Computer.threadPoolForRemoting.submit(() -> {
             try {
-                nodePools.provisionNode(label, wi.task);
+                nodePools.provisionNode(label, wi.task, wi.getId());
             } catch (Exception ex) {
                 LOG.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
             }

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolsTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolsTest.java
@@ -141,8 +141,10 @@ public class NodePoolsTest {
     @Test
     public void testProvisionNode() throws Exception {
         nps.getNodePools().add(m.np);
-        nps.provisionNode(m.label, m.task);
-        verify(m.np).provisionNode(m.label, m.task);
+        nps.provisionNode(m.label, m.task, 0);
+
+        final NodePoolJob job = new NodePoolJob(m.label, m.task, 0);
+        verify(m.np).provisionNode(job);
     }
 
     /**


### PR DESCRIPTION
Requests for a NodePool node will now be tried up to 3 times before
giving up and cancelling a Jenkins task.

Progress tracking has been added in the NodePoolJob class, which can
be utilized in a future tool to visualize the state of request
request progress across all tasks.