### PR TITLE
Add a management link to view NodePool history

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
@@ -618,4 +618,8 @@ public class NodePool implements Describable<NodePool> {
         }
     }
 
+    @Override
+    public String toString() {
+        return connectionString;
+    }
 }

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJobHistory.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJobHistory.java
@@ -1,0 +1,65 @@
+package com.rackspace.jenkins_nodepool;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Track historical information about Jenkins jobs handled by the plugin.
+ */
+public class NodePoolJobHistory implements Iterable<NodePoolJob> {
+
+    private static final int MAX_HISTORY_LENTH = 100;
+    private final Object lock = new Object();
+
+    private final List<NodePoolJob> jobs;
+    private final int maxHistoryLength;
+
+    public NodePoolJobHistory() {
+        this(MAX_HISTORY_LENTH);
+    }
+
+    public NodePoolJobHistory(final int maxHistoryLenth) {
+        this.maxHistoryLength = maxHistoryLenth;
+        jobs = new ArrayList<>(maxHistoryLenth);
+    }
+
+    /**
+     * Add job and prune the historical list if necessary.
+     *
+     * @param job a job
+     */
+    public void add(NodePoolJob job) {
+
+        synchronized(lock) {
+            jobs.add(0, job);
+
+            while (jobs.size() > maxHistoryLength) {
+                final int last = jobs.size() - 1;
+                jobs.remove(last);
+            }
+        }
+    }
+
+    @Override
+    public Iterator<NodePoolJob> iterator() {
+        // copy the underlying list and return -- avoid concurrent modification issues
+        List<NodePoolJob> jobsCopy;
+        synchronized(lock) {
+            jobsCopy = new ArrayList<>(this.jobs);
+        }
+        return jobsCopy.iterator();
+    }
+
+    NodePoolJob getJob(long taskId) {
+
+        final Iterator<NodePoolJob> iter = iterator();
+        while (iter.hasNext()) {
+            final NodePoolJob job = iter.next();
+            if (job.getTaskId() == taskId) {
+                return job;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodeRequest.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodeRequest.java
@@ -29,6 +29,7 @@ import hudson.model.Queue.Task;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -110,6 +111,19 @@ public class NodeRequest extends ZooKeeperObject {
     }
 
     /**
+     * Get node names only from the local cache of the ZNode
+     *
+     * @return list of node names
+     */
+    public List<String> getAllocatedNodeNames() {
+        List<String> nodes = (List<String>)data.get("nodes");
+        if (nodes == null) {
+            nodes = Collections.emptyList();
+        }
+        return nodes;
+    }
+
+    /**
      * Get list of NodePool nodes that have been allocated to fulfill this request
      *
      * @return  list of nodes
@@ -125,7 +139,7 @@ public class NodeRequest extends ZooKeeperObject {
         if (data.get("state") != RequestState.fulfilled) {
             throw new IllegalStateException("Attempt to get allocated nodes from a node request before it has been fulfilled");
         }
-        final List<NodePoolNode> nodeObjects = new ArrayList();
+        final List<NodePoolNode> nodeObjects = new ArrayList<>();
         for (Object id : (List) data.get("nodes")) {
             nodeObjects.add(new NodePoolNode(nodePool, (String) id));
         }

--- a/src/main/java/com/rackspace/jenkins_nodepool/links/NodePoolManagementLink.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/links/NodePoolManagementLink.java
@@ -1,0 +1,50 @@
+package com.rackspace.jenkins_nodepool.links;
+
+import com.rackspace.jenkins_nodepool.NodePool;
+import com.rackspace.jenkins_nodepool.NodePoolJobHistory;
+import com.rackspace.jenkins_nodepool.NodePools;
+import hudson.Extension;
+
+import javax.annotation.CheckForNull;
+import java.util.List;
+
+/**
+ * Adds a link under "Manage Jenkins" which can be accessed to display information related to the health and
+ * functioning of the Jenkins+NodePool environment.
+ */
+@Extension
+public class NodePoolManagementLink extends hudson.model.ManagementLink {
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return "network.png";
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return "NodePool";
+    }
+
+    @Override
+    public String getDescription() {
+        return "View health and diagnostic information related to the NodePool plugin.";
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return "nodepool-view";
+    }
+
+    public List<NodePool> getNodePools() {
+        final NodePools nodePools = NodePools.get();
+        return nodePools.getNodePools();
+    }
+
+    public NodePoolJobHistory getJobHistory() {
+        final NodePools nodePools = NodePools.get();
+        return nodePools.getJobHistory();
+    }
+}

--- a/src/main/resources/com/rackspace/jenkins_nodepool/links/NodePoolManagementLink/index.jelly
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/links/NodePoolManagementLink/index.jelly
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+
+    <l:layout norefresh="true" permission="${app.READ}" title="NodePool View">
+        <st:include page="sidepanel.jelly" it="${app}"/>
+
+        <l:main-panel>
+
+            <h1>
+                <l:icon class="icon-terminal icon-xlg"/>
+                NodePool debug view
+            </h1>
+            <p>Use the following table to see how runs of Jenkins projects resulted in the
+            creation of new Jenkins nodes from NodePool.</p>
+            <p>(Note: <i>SUCCESS</i> means that for a given build of a job, it was able to successfully obtain node(s)
+                from NodePool, not necessarily that the job itself ran to a successful completion.)
+            </p>
+
+            <h2>
+                Build history
+            </h2>
+
+            <p>
+                <j:set var="jobHistory" value="${it.jobHistory}"/>
+
+                <table class="bigtable">
+                    <tr>
+                        <th>Task Name</th>
+                        <th>Queue Id</th>
+                        <th>Build #</th>
+                        <th>Label</th>
+                        <th>NodePool cluster</th>
+                        <th>Complete?</th>
+                        <th>Result</th>
+                        <th>Duration</th>
+                        <th>Attempts</th>
+                    </tr>
+
+                <j:forEach var="job" items="${jobHistory}">
+                    <j:set var="task" value="${job.task}"/>
+
+                    <tr>
+                        <td>${task.fullDisplayName}</td>
+                        <td>${job.taskId}</td>
+                        <td>${job.buildNumber}</td>
+                        <td>${job.label}</td>
+                        <th>${job.nodePool}</th>
+                        <td><j:choose>
+                                <j:when test="${job.done}">yes</j:when>
+                                <j:otherwise>no</j:otherwise>
+                            </j:choose></td>
+                        <td><j:choose>
+                            <j:when test="${job.success}">success</j:when>
+                            <j:otherwise>failure</j:otherwise>
+                        </j:choose></td>
+
+                        <td>${job.durationSeconds} secs</td>
+                        <td>
+                            <ul>
+                                <j:set var="attempts" value="${job.attempts}"/>
+                                <j:forEach var="attempt" items="${attempts}">
+                                    <li>${attempt}
+                                        <j:if test="${attempt.failure}">
+                                            <ul>
+                                                <li><pre>${attempt.error}</pre></li>
+                                            </ul>
+                                        </j:if>
+                                    </li>
+                                </j:forEach>
+                            </ul>
+
+                        </td>
+                    </tr>
+                </j:forEach>
+
+                </table>
+            </p>
+
+        </l:main-panel>
+    </l:layout>
+</j:jelly>
+
+

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobHistoryTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobHistoryTest.java
@@ -1,0 +1,82 @@
+package com.rackspace.jenkins_nodepool;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class NodePoolJobHistoryTest {
+
+    private static final int maxHistoryLength = 2;
+    private NodePoolJobHistory nodePoolJobHistory;
+
+    @Before
+    public void setUp() {
+        nodePoolJobHistory = new NodePoolJobHistory(maxHistoryLength);
+    }
+
+    @Test
+    public void testAddJob() {
+        final NodePoolJob job = new NodePoolJob(null, null, 1);
+        nodePoolJobHistory.add(job);
+
+        int sz = 0;
+        final Iterator<NodePoolJob> iter = nodePoolJobHistory.iterator();
+
+        NodePoolJob j = null;
+        while (iter.hasNext()) {
+            j = iter.next();
+            sz += 1;
+        }
+
+        assertEquals(1, sz);
+        assertEquals(job, j);
+    }
+
+    @Test
+    public void testAddJobPruning() {
+        // test pruning of excess jobs.
+        for (int i = 0; i < maxHistoryLength + 1; i++ ) {
+            nodePoolJobHistory.add(
+                    new NodePoolJob(null, null, i)
+            );
+        }
+
+        final Iterator<NodePoolJob> iter = nodePoolJobHistory.iterator();
+        int sz = 0;
+
+        while (iter.hasNext()) {
+            iter.next();
+            sz += 1;
+        }
+
+        assertEquals(maxHistoryLength, sz);
+    }
+
+    @Test
+    public void testGetJob() {
+        nodePoolJobHistory.add(
+                new NodePoolJob(null, null, 1)
+        );
+
+        nodePoolJobHistory.add(
+                new NodePoolJob(null, null, 42)
+        );
+
+        final NodePoolJob job = nodePoolJobHistory.getJob(42);
+        assertNotNull(job);
+    }
+
+    @Test
+    public void testGetJobNonExistent() {
+        nodePoolJobHistory.add(
+                new NodePoolJob(null, null, 1)
+        );
+
+        assertNull(nodePoolJobHistory.getJob(2));
+    }
+}

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobTest.java
@@ -1,0 +1,57 @@
+package com.rackspace.jenkins_nodepool;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.Label;
+import hudson.model.Queue;
+import hudson.model.labels.LabelAtom;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NodePoolJobTest {
+
+    private final long taskId = 42;
+    private final Label label = new LabelAtom("mylabel");
+
+    private final Queue.Task task = new FreeStyleProject((ItemGroup)null, "myproject");
+    private final NodePoolJob job = new NodePoolJob(label, task, taskId);
+
+    @Test
+    public void testGetLabel() {
+        assertEquals(label, job.getLabel());
+    }
+
+    @Test
+    public void testGetTask() {
+        assertEquals(task, job.getTask());
+    }
+
+    @Test
+    public void testGetTaskId() {
+        assertEquals(taskId, job.getTaskId());
+    }
+
+    @Test
+    public void testSuccess() {
+        job.addAttempt(null);
+        job.failAttempt(new Exception("a bad thing happened."));
+
+        job.addAttempt(null);
+        job.succeed();
+
+        assertEquals(2, job.getAttempts().size());
+        assertTrue(job.isSuccess());
+    }
+
+    @Test
+    public void testFailure() {
+        job.addAttempt(null);
+        job.failAttempt(new Exception("could be better."));
+
+        assertTrue(job.isDone());
+        assertFalse(job.isSuccess());
+    }
+}


### PR DESCRIPTION
Adds a management link to visualize how the NodePool plugin created
nodes for various Jenkins jobs.

Home => Manage Jenkins => NodePool

RE-1445