### PR TITLE
RE-1502 Tighten regex for specific nodes

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueListener.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueListener.java
@@ -70,7 +70,7 @@ public class NodePoolQueueListener extends QueueListener {
         // job that caused them.
         // Note that this won't kill builds for non NodePool labels as we check
         // for a prefix match.
-        if (!nps.isEmpty() && Pattern.matches(".*-[0-9]+$", label.getName())) {
+        if (!nps.isEmpty() && Pattern.matches(".*-[0-9]{10}$", label.getName())) {
             LOG.log(Level.WARNING, "Killing queued task {0} as it refers to specific NodePool node {1}", new Object[]{wi.task, label});
             Jenkins.getInstance().getQueue().cancel(wi.task);
             return;


### PR DESCRIPTION
There is some code in NodePoolQueueListener that attempts to detect
when a build is requesting a specific node rather than a general label
the idea being that builds should never request a specific node, so
those builds will be cancelled.

However we introduced general labels that end with a number and
legitimate jobs were being cancelled.

This patch tightens up the regex so that only labels that end with
dash then ten digits will be caught as nodepool ids are 10 digits long.

Ideally we would get a list of labels from nodepool and compare
agianst that instead of pattern matching, but I can't see a way
of doing that.