### PR TITLE
HS-RE-1778 Add provider label

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolLabelFinder.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolLabelFinder.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Rackspace.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.rackspace.jenkins_nodepool;
+
+import hudson.Extension;
+import hudson.model.LabelFinder;
+import hudson.model.Node;
+import hudson.model.labels.LabelAtom;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * Add provider label to Node Pool Slaves
+ * @author Rackspace
+ */
+@Extension
+public class NodePoolLabelFinder extends LabelFinder {
+
+    @Override
+    public Collection<LabelAtom> findLabels(Node node) {
+        Set<LabelAtom> labels = new HashSet<>();
+
+        if(node instanceof NodePoolSlave){
+            NodePoolSlave nps = (NodePoolSlave) node;
+            NodePoolNode npn = nps.getNodePoolNode();
+            if(npn != null){
+                String provider = npn.getProvider();
+                labels.add(new LabelAtom(provider));
+            }
+        }
+
+        return labels;
+    }
+
+}

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolNode.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolNode.java
@@ -1,11 +1,10 @@
 package com.rackspace.jenkins_nodepool;
 
+import static java.lang.String.format;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.lang.String.format;
 
 
 /**
@@ -72,6 +71,14 @@ public class NodePoolNode extends ZooKeeperObject {
                     o.getClass().getTypeName()));
             return new ArrayList<>();
         }
+    }
+
+    /**
+     * Get the name of the provider that provisioned this node
+     * @return String name of the provider
+     */
+    public String getProvider(){
+        return (String) data.get("provider");
     }
 
     /**


### PR DESCRIPTION
Add label to NodePool Nodes that corresponds to the provider that
provisioned it.

This should not be required in general, but may be useful for testing
or avoiding a specific provider/region.

Note that the provider name will be as configured in nodepool.