### PR TITLE
RE-1842 HoldStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 This repository contains a Jenkins plugin to perform builds on cloud instance  nodes sourced
 from [NodePool](https://docs.openstack.org/infra/nodepool/).
 
+## Pipeline Steps
+### nodePoolHold
+This step allows a user to hold the current node from within a job, assuming
+the current node is a node pool node.
+
+Usage:
+```
+    node("nodepool-debian"){
+        nodePoolHold() // hold for one day
+        nodePoolHold("1w") // hold for one week
+        nodePoolHold("1w", "Investigating issue IS-123") // specify reason
+    }
+```
+The hold end time will be calculated from the specified duration
+and is visible on the Computer page in the Jenkins UI for each
+nodepool node. The reason is also visible in the same place.
+
 ## Structure
 
 The implementation consists of a listener class that creates agents (slaves) when a item with a

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,11 @@
             <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.10</version>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/main/java/com/rackspace/jenkins_nodepool/HoldStep.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/HoldStep.java
@@ -1,0 +1,147 @@
+package com.rackspace.jenkins_nodepool;
+
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Computer;
+import hudson.model.Executor;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.tasks.SimpleBuildStep;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Rackspace.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ *
+ * @author Rackspace
+ */
+public class HoldStep extends Builder implements SimpleBuildStep {
+
+    private static final Logger LOG = Logger.getLogger(HoldStep.class.getName());
+
+    private final String reason;
+    private final String duration;
+    private PrintStream consoleLog;
+
+    @DataBoundConstructor
+    public HoldStep(String duration, String reason){
+        this.reason = reason;
+        this.duration = duration;
+    }
+
+    public HoldStep(String duration){
+        this(duration, "Held from Pipeline Step");
+    }
+
+    public HoldStep(){
+        this("1d");
+    }
+
+    public String getReason(){
+        return reason;
+    }
+    public String getDuration(){
+        return duration;
+    }
+
+    private void log(String message, Level level){
+        consoleLog.println(message);
+        LOG.log(level, message);
+    }
+    private void log(String message){
+        log(message, Level.INFO);
+    }
+    private void setConsoleLogger(PrintStream logger){
+        this.consoleLog = logger;
+    }
+
+    @Override
+    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
+        setConsoleLogger(listener.getLogger());
+        // try and find the current computer
+        // use a few different methods so freestyle and pipeline jobs work
+        Executor executor = Executor.currentExecutor();
+        VirtualChannel vc = launcher.getChannel();
+        FilePath fp = new FilePath(vc, "/");
+        Job job = run.getParent();
+
+        Computer computer;
+        if (executor != null){
+            computer = executor.getOwner();
+        } else if (Computer.currentComputer() != null) {
+            computer = Computer.currentComputer();
+        } else if(fp.toComputer() != null){
+            computer = fp.toComputer();
+        } else {
+            log("Can't hold as theres no node allocated :(");
+            return;
+        }
+
+        if (computer instanceof NodePoolComputer){
+            try {
+                NodePoolComputer npc = (NodePoolComputer) computer;
+                NodePoolSlave nps = (NodePoolSlave) npc.getNode();
+                if (nps != null){
+                    String build_id = job.getDisplayName()+"-"+run.getNumber();
+                    nps.setHeld(true);
+                    nps.setHoldReason(reason);
+                    nps.setHoldUser(build_id);
+                    nps.setHoldUntil(duration, true);
+                    log("Held node: " + npc.toString());
+                }
+            } catch (Exception ex) {
+                log("Failed to hold node: "+ex.toString(), Level.SEVERE);
+            }
+        }else {
+            log("Can't hold as the current node is not a nodepool node");
+        }
+    }
+
+    @Symbol("nodePoolHold")
+    @Extension
+    public static class DescriptorImple extends BuildStepDescriptor<Builder>{
+        @Override
+        public String getDisplayName() {
+            return "Set NodePool hold from within a job";
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> t) {
+            return true;
+        }
+    }
+}

--- a/src/main/resources/com/rackspace/jenkins_nodepool/HoldStep/config.jelly
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/HoldStep/config.jelly
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<!-- TODO add taglibs such as: xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" -->
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+     <f:entry title="${%Hold Reason}" field="reason">
+            <f:textbox name="holdReason" maxlength="256"
+                       placeholder="Why is this node being held?"/>
+    </f:entry>
+    
+    <f:entry title="${%Hold Until}" field="duration">
+            <!-- Change into a drop down list ?? -->
+            <f:textbox name="holdUntil" maxlength="3"
+                       placeholder="enter a period such as: 10m, 6h, 3d, 3w, 1M - default is 1d"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/rackspace/jenkins_nodepool/HoldStep/help-duration.html
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/HoldStep/help-duration.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    Allows the user to specify how long to hold the nodepool node.  Default is 1 day. The value should be a positive
+    integer between 1 and 99 inclusive with a one letter unit signifying how long to hold the node (m=minutes, h=hours,
+    d=days, w=weeks, M=months). However, maximum hold duration is 1 month. Examples include: 40m, 1h, 6h, 3d, 3w, 1M.
+</div>


### PR DESCRIPTION
Adds a hold step to the Nodepool Agents plugin, this lets
a user configure a freestle or pipeline job to hold the
current node from within a job.

Example:
    node("nodepool-debian"){
        nodePoolHold("testing")
    }