### PR TITLE
RE-1971 Queue Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ hs_err_pid*
 
 # Ignore Virtual Env in docker folder
 docker/.venv/
+/nbproject/

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>0.0.15-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>NodePool Agents Plugin</name>
@@ -107,7 +107,7 @@
                             <properties>
                                 <property>
                                     <name>java.util.logging.SimpleFormatter.format</name>
-                                    <value>[%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS%tz][%4$s] %2$s %5$s%6$s%n</value>
+                                    <value>[%4$.4s][%1$tY-%1$tm-%1$tdT%1$tH:%1$tM:%1$tS%tz] %2$s %5$s%6$s%n</value>
                                 </property>
                             </properties>
                         </configuration>
@@ -177,25 +177,46 @@
             <version>3.0.14</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ssh-slaves</artifactId>
-            <version>1.26</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.1.11</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.25</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ssh-slaves</artifactId>
+            <version>1.26</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.18</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ssh-credentials</artifactId>
+            <version>1.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/rackspace/jenkins_nodepool/Attempt.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/Attempt.java
@@ -103,13 +103,13 @@ public final class Attempt {
         return isDone() && e == null;
     }
 
-    public NodePoolJob.Status getResult() {
+    public NodePoolJob.NodeRequestAttemptState getResult() {
         if (!isDone()) {
-            return NodePoolJob.Status.INPROGRESS;
+            return NodePoolJob.NodeRequestAttemptState.INPROGRESS;
         } else if (isSuccess()) {
-            return NodePoolJob.Status.SUCCESS;
+            return NodePoolJob.NodeRequestAttemptState.SUCCESS;
         } else {
-            return NodePoolJob.Status.FAILURE;
+            return NodePoolJob.NodeRequestAttemptState.FAILURE;
         }
     }
 

--- a/src/main/java/com/rackspace/jenkins_nodepool/HoldStep.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/HoldStep.java
@@ -121,7 +121,9 @@ public class HoldStep extends Builder implements SimpleBuildStep {
                     nps.setHoldReason(reason);
                     nps.setHoldUser(build_id);
                     nps.setHoldUntil(duration, true);
-                    log("Held node: " + npc.toString());
+                    log("Held node: " + npc.toString()
+                      + " IP:"+nps.getNodePoolNode().getHost()
+                      + " Hold Expiry Time: "+nps.getHoldUntilTimeFormatted());
                 }
             } catch (Exception ex) {
                 log("Failed to hold node: "+ex.toString(), Level.SEVERE);

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJob.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJob.java
@@ -1,10 +1,14 @@
 package com.rackspace.jenkins_nodepool;
 
 import hudson.model.*;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 /**
  * Wrap a Jenkins task so we can track some information over the NodePool processing cycle.
@@ -13,19 +17,76 @@ public class NodePoolJob {
 
     private Label label; // jenkins label
     private final Queue.Task task;
-    private long taskId;
-    private Integer buildNumber;
+    private final long queueID;
+    private final WorkflowRun run;
+    private final Job job;
+    private NodePoolNode nodePoolNode = null;
+    private NodePoolSlave nodePoolSlave = null;
 
     /**
      * A list of Attempt objects to hold the metadata associated with each provision attempt.
      */
     private List<Attempt> attempts = new ArrayList<>();
 
-    NodePoolJob(Label label, Queue.Task task, long taskId) {
+    NodePoolJob(Label label, Queue.Task task, long queueID) {
         this.label = label;
+        this.queueID = queueID;
         this.task = task;
-        this.taskId = taskId;
-        this.buildNumber = null;
+        this.run = NodePoolUtils.getRunForQueueTask(task);
+        this.job = run.getParent();
+        logToBoth("NodepoolJob "+this.toString()+" tracking node usage with label: "+this.label.getDisplayName());
+    }
+
+
+    /**
+     * Get string identifying the build that created this task
+     * @return jobName#buildNum
+     */
+    public String getBuildId(){
+        return run.getExternalizableId();
+    }
+
+    public String getOverviewString(){
+        return String.format("Queue Item: %s, %s Build: %s-%s, %s",
+            queueID,// Queue ID
+            task.toString(),// Queue Status
+            job.getDisplayName(),// Job Name
+            run.getNumber(), // Build Number
+            run.getBuildStatusSummary().message// Build Status
+        );
+    }
+
+    public NodePoolSlave getNodePoolSlave(){
+        return nodePoolSlave;
+    }
+
+    public NodePoolNode getNodePoolNode() {
+        return nodePoolNode;
+    }
+
+    public void setNodePoolNode(NodePoolNode nodePoolNode) {
+        this.nodePoolNode = nodePoolNode;
+    }
+
+    public void setNodePoolSlave(NodePoolSlave nodePoolSlave) {
+        this.nodePoolSlave = nodePoolSlave;
+    }
+
+    public Run getRun(){
+        return run;
+    }
+
+    public List<NodeRequest> getRequests(){
+        return attempts
+                .stream()
+                .map(a -> a.getRequest())
+                .collect(Collectors.toList());
+    }
+
+    public Boolean hasRequest(NodeRequest request){
+        return getRequests()
+                .stream()
+                .anyMatch(r -> r.equals(request));
     }
 
     public Label getLabel() {
@@ -37,19 +98,58 @@ public class NodePoolJob {
     }
 
     public long getTaskId() {
-        return this.taskId;
+        return this.queueID;
+    }
+
+    /**
+     * Write message to system log and build log with level INFO.
+     * @param msg the message to log
+     */
+    public void logToBoth(String msg){
+        logToBoth(msg, Level.INFO);
+    }
+
+    /**
+     * Writes log message to the Jenkins System log and the relevant build log
+     * @param msg the message to log
+     * @param level the log level to use for the system log
+     */
+    public void logToBoth(String msg, Level level){
+        Logger.getLogger(NodePoolJob.class.getName()).log(
+                level,
+                msg);
+        if (run != null){
+            WorkflowRun wr = (WorkflowRun) run;
+            try {
+                FlowExecutionOwner feo = wr.asFlowExecutionOwner();
+                // findbugs
+                if (feo == null){
+                    return;
+                }
+                TaskListener tl = feo.getListener();
+                tl.getLogger().println(msg);
+            } catch (Exception ex) {
+                //Deliberately wide catch, so NPEs are included.
+                Logger.getLogger(NodePoolJob.class.getName()).log(Level.SEVERE,
+                        "Failed to log to build console.");
+            }
+        }
     }
 
     void addAttempt(NodeRequest request) {
         attempts.add(new Attempt(request));
+        logToBoth("Nodepool Node Requested: "+request.toString());
     }
 
     void failAttempt(Exception e) {
+        logToBoth("Nodepool Node Requested Failed: "+e.toString());
         // mark current attempt as a failure
         getCurrentAttempt().fail(e);
     }
 
     void succeed() {
+        logToBoth("Nodepool Node Requested Succeded: "
+                +getCurrentAttempt().getRequest().toString());
         getCurrentAttempt().succeed();
     }
 
@@ -115,10 +215,10 @@ public class NodePoolJob {
      * @return build number of Jenkins project
      */
     public String getBuildNumber() {
-        if (buildNumber == null) {
+        if (run ==  null){
             return "";
         } else {
-            return "#" + String.valueOf(buildNumber);
+            return "#" + String.valueOf(run.number);
         }
     }
 
@@ -127,28 +227,14 @@ public class NodePoolJob {
      *
      * @return the result associated with the current attempt.
      */
-    public Status getResult() {
+    public NodeRequestAttemptState getResult() {
         return getCurrentAttempt().getResult();
-    }
-
-    /**
-     * Sets the build number value.
-     *
-     * @param buildNumber the build number value
-     * @throws IllegalArgumentException if the buildNumber is negative.
-     */
-    public void setBuildNumber(int buildNumber) {
-        if (buildNumber < 0) {
-            throw new IllegalArgumentException("Build number was negative: " + buildNumber);
-        }
-
-        this.buildNumber = buildNumber;
     }
 
     /**
      * A status enumeration to hold the attempt status.
      */
-    public enum Status {
+    public enum NodeRequestAttemptState {
         INPROGRESS,
         SUCCESS,
         FAILURE
@@ -165,10 +251,10 @@ public class NodePoolJob {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final NodePoolJob that = (NodePoolJob) o;
-        return taskId == that.taskId &&
+        return getTaskId() == that.getTaskId() &&
                 Objects.equals(label, that.label) &&
                 Objects.equals(task, that.task) &&
-                Objects.equals(buildNumber, that.buildNumber);
+                Objects.equals(getBuildNumber(), that.getBuildNumber());
     }
 
     /**
@@ -178,7 +264,7 @@ public class NodePoolJob {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(label, task, taskId, buildNumber);
+        return Objects.hash(label, task, getTaskId(), getBuildNumber());
     }
 
     /**
@@ -188,7 +274,7 @@ public class NodePoolJob {
      */
     @Override
     public String toString() {
-        return "NodePoolJob[taskId=" + taskId + ", task=" + task.getFullDisplayName() + ", label=" + label + "]";
+        return "NodePoolJob[taskId=" + getTaskId() + ", task=" + task.getFullDisplayName() + ", label=" + label + "]";
     }
 
 }

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJobHistory.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJobHistory.java
@@ -3,13 +3,14 @@ package com.rackspace.jenkins_nodepool;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Track historical information about Jenkins jobs handled by the plugin.
  */
 public class NodePoolJobHistory implements Iterable<NodePoolJob> {
 
-    private static final int MAX_HISTORY_LENGTH = 100;
+    private static final int MAX_HISTORY_LENGTH = 250;
     private final Object lock = new Object();
 
     private final List<NodePoolJob> jobs;
@@ -51,6 +52,11 @@ public class NodePoolJobHistory implements Iterable<NodePoolJob> {
         return jobsCopy.iterator();
     }
 
+    /**
+     * Find job matching taskID
+     * @param taskId
+     * @return
+     */
     NodePoolJob getJob(long taskId) {
 
         final Iterator<NodePoolJob> iter = iterator();
@@ -62,4 +68,45 @@ public class NodePoolJobHistory implements Iterable<NodePoolJob> {
         }
         return null;
     }
+
+    /**
+     * Find job matching request object
+     * @param request
+     * @return
+     */
+    NodePoolJob getJob(NodeRequest request){
+        return jobs
+            .stream()
+            .filter(j -> j.hasRequest(request))
+            .findFirst()
+            .get();
+    }
+
+    /**
+     * Find jobs matching JobName
+     * @param jobName
+     * @return
+     */
+    List<NodePoolJob> getJobs(String jobName){
+        return jobs.stream()
+                .filter(j -> j.getRun().getDisplayName().equals(jobName))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Find jobs matching JobName and Build number
+     * There could be multiple as each job represents a usage
+     * of a nodepool node and a build may use multiple nodes.
+     * @param jobName
+     * @param buildNum
+     * @return
+     */
+    List<NodePoolJob> getJobs(String jobName, Integer buildNum){
+        return jobs.stream()
+                .filter(j -> j.getRun().getDisplayName().equals(jobName) &&
+                        j.getRun().getNumber() == buildNum)
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueTaskDispatcher.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueTaskDispatcher.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Rackspace.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.rackspace.jenkins_nodepool;
+
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.Queue.BuildableItem;
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueTaskDispatcher;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+/**
+ * Ensure that nodepool nodes only execute the one task they were
+ * created for. All other tasks are rejected.
+ * @author Rackspace
+ */
+@Extension
+public class NodePoolQueueTaskDispatcher extends QueueTaskDispatcher {
+
+
+    /**
+     * Check if a node can take a task.
+     * This is the non-deprecated signature, though its hard to
+     * test, so the logic is in cantake(Node node, Queue.Task task)
+     * @param node The node which might execute the task
+     * @param item An item that conatins a task reference to be executed
+     * @return null if the task can be allocated to the node, otherwise a CauseOfBlockage
+     */
+    @Override
+    public CauseOfBlockage canTake(Node node, BuildableItem item){
+        return canTake(node, item.task);
+    }
+
+    @Override
+    public CauseOfBlockage canTake(Node node, Queue.Task task) {
+        if(!(node instanceof NodePoolSlave)){
+            // not a nodepool node, so we don't block any tasks
+            return null;
+        } else {
+            // safe cast due to if
+            NodePoolSlave nps = (NodePoolSlave) node;
+            WorkflowRun itemRun = NodePoolUtils.getRunForQueueTask(task);
+            WorkflowRun nodeRun = (WorkflowRun)nps.getNodePoolJob().getRun();
+
+            if (itemRun.equals(nodeRun)){
+                // this node was allocated for this task, approve allocation
+                return null;
+            } else {
+                // This is a nodepool node, but it was created for a different
+                // build, so block this task allocation
+                return new NodeCreatedForAnotherBuildCauseOfBlockage();
+            }
+        }
+    }
+
+    public static class NodeCreatedForAnotherBuildCauseOfBlockage extends CauseOfBlockage{
+
+        @Override
+        public String getShortDescription() {
+            return "Attempting to assign a task to a NodePool node that was created for a different build";
+        }
+
+    }
+
+
+}

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePoolSlave/configure-entries.jelly
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePoolSlave/configure-entries.jelly
@@ -55,6 +55,12 @@
                       style="background-color: #ededed;"/>
         </f:entry>
     </f:section>
+    
+    <f:section title="${%Created For}">
+        <f:entry title="${%Job}">
+            <a href="${it.getBuildUrl()}">${it.getJob().getRun().getExternalizableId()}</a>
+        </f:entry>
+    </f:section>
 
     <f:section title="${%Connectivity}">
         <f:entry title="${%IP Address}">

--- a/src/test/java/com/rackspace/jenkins_nodepool/KazooLockTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/KazooLockTest.java
@@ -92,7 +92,7 @@ public class KazooLockTest {
         assertEquals(0, children.size());
 
         // create and acquire lock
-        KazooLock kl = new KazooLock(path, m.np);
+        KazooLock kl = new KazooLock(path, m.np, m.npj);
         assertEquals(KazooLock.State.UNLOCKED, kl.getState());
         kl.acquire();
         assertEquals(KazooLock.State.LOCKED, kl.getState());
@@ -113,7 +113,7 @@ public class KazooLockTest {
     @Test(expected = KazooLockException.class)
     public void testBlockingAcquireTimesOut() throws Exception {
         // create and acquire lock
-        final KazooLock kl = new KazooLock(path, 1, TimeUnit.SECONDS, m.np);
+        final KazooLock kl = new KazooLock(path, 1, TimeUnit.SECONDS, m.np, m.npj);
         kl.acquire();
 
         // lock is not reentrant, so second acquire should timeout
@@ -152,8 +152,8 @@ public class KazooLockTest {
 
         // Create two contenders for a single lock. One for this thread and one
         // for the background thread.
-        KazooLock kl = new KazooLock(path, m.np);
-        KazooLock klBackground = new KazooLock(path, m.np);
+        KazooLock kl = new KazooLock(path, m.np, m.npj);
+        KazooLock klBackground = new KazooLock(path, m.np, m.npj);
 
         LockHolder background = new LockHolder(klBackground);
         klBackground.acquire(); // Acquire lock before starting background

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolComputerTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolComputerTest.java
@@ -23,16 +23,13 @@
  */
 package com.rackspace.jenkins_nodepool;
 
-import static org.junit.Assert.assertEquals;
-
 import hudson.model.Executor;
 import hudson.model.Queue;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
@@ -50,7 +47,7 @@ public class NodePoolComputerTest {
     @Before
     public void setUp() {
         m = new Mocks();
-        npc = new NodePoolComputer(m.nps, m.npn);
+        npc = new NodePoolComputer(m.nps, m.npn, m.npj);
     }
 
     /**

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobHistoryTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobHistoryTest.java
@@ -1,27 +1,27 @@
 package com.rackspace.jenkins_nodepool;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Iterator;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import org.junit.Before;
+import org.junit.Test;
 
 public class NodePoolJobHistoryTest {
 
     private static final int maxHistoryLength = 2;
     private NodePoolJobHistory nodePoolJobHistory;
+    private Mocks m;
 
     @Before
     public void setUp() {
         nodePoolJobHistory = new NodePoolJobHistory(maxHistoryLength);
+        m = new Mocks();
     }
 
     @Test
     public void testAddJob() {
-        final NodePoolJob job = new NodePoolJob(null, null, 1);
+        final NodePoolJob job = new NodePoolJob(m.label, m.task, m.qID);
         nodePoolJobHistory.add(job);
 
         int sz = 0;
@@ -42,7 +42,7 @@ public class NodePoolJobHistoryTest {
         // test pruning of excess jobs.
         for (int i = 0; i < maxHistoryLength + 1; i++ ) {
             nodePoolJobHistory.add(
-                    new NodePoolJob(null, null, i)
+                    new NodePoolJob(m.label, m.task, m.qID)
             );
         }
 
@@ -59,22 +59,19 @@ public class NodePoolJobHistoryTest {
 
     @Test
     public void testGetJob() {
-        nodePoolJobHistory.add(
-                new NodePoolJob(null, null, 1)
-        );
 
         nodePoolJobHistory.add(
-                new NodePoolJob(null, null, 42)
+            new NodePoolJob(m.label, m.task, m.qID)
         );
 
-        final NodePoolJob job = nodePoolJobHistory.getJob(42);
+        final NodePoolJob job = nodePoolJobHistory.getJob(m.qID);
         assertNotNull(job);
     }
 
     @Test
     public void testGetJobNonExistent() {
         nodePoolJobHistory.add(
-                new NodePoolJob(null, null, 1)
+            new NodePoolJob(m.label, m.task, m.qID)
         );
 
         assertNull(nodePoolJobHistory.getJob(2));

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolJobTest.java
@@ -1,23 +1,28 @@
 package com.rackspace.jenkins_nodepool;
 
-import hudson.model.FreeStyleProject;
-import hudson.model.ItemGroup;
 import hudson.model.Label;
-import hudson.model.Queue;
 import hudson.model.labels.LabelAtom;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
 public class NodePoolJobTest {
 
+    private Mocks m = new Mocks();
     private final long taskId = 42;
     private final Label label = new LabelAtom("mylabel");
 
-    private final Queue.Task task = new FreeStyleProject((ItemGroup)null, "myproject");
-    private final NodePoolJob job = new NodePoolJob(label, task, taskId);
+    //private final Queue.Task task = new FreeStyleProject((ItemGroup)null, "myproject");
+    //private final Queue.Item item = new Queue.WaitingItem(new GregorianCalendar(), task, new ArrayList<>());
+    private NodePoolJob job = new NodePoolJob(label, m.task, m.qID);
+
+    @Before
+    public void before(){
+        m = new Mocks();
+        job = new NodePoolJob(label, m.task, m.qID);
+    }
 
     @Test
     public void testGetLabel() {
@@ -26,7 +31,7 @@ public class NodePoolJobTest {
 
     @Test
     public void testGetTask() {
-        assertEquals(task, job.getTask());
+        assertEquals(m.task, job.getTask());
     }
 
     @Test
@@ -36,10 +41,10 @@ public class NodePoolJobTest {
 
     @Test
     public void testSuccess() {
-        job.addAttempt(null);
+        job.addAttempt(m.nr);
         job.failAttempt(new Exception("a bad thing happened."));
 
-        job.addAttempt(null);
+        job.addAttempt(m.nr);
         job.succeed();
 
         assertEquals(2, job.getAttempts().size());
@@ -48,7 +53,7 @@ public class NodePoolJobTest {
 
     @Test
     public void testFailure() {
-        job.addAttempt(null);
+        job.addAttempt(m.nr);
         job.failAttempt(new Exception("could be better."));
 
         assertTrue(job.isDone());

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolNodeTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolNodeTest.java
@@ -23,13 +23,11 @@
  */
 package com.rackspace.jenkins_nodepool;
 
-import org.junit.*;
-
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import org.junit.*;
 import static org.junit.Assert.*;
 
 /**
@@ -66,7 +64,7 @@ public class NodePoolNodeTest {
             m.conn.create()
                     .creatingParentsIfNeeded()
                     .forPath(nodePath, m.jsonString.getBytes(m.charset));
-            npn = new NodePoolNode(m.np, m.npID);
+            npn = new NodePoolNode(m.np, m.npID, m.npj);
             // Type field now holds a list of string values
             final List<String> types = new ArrayList<>();
             types.add(m.npLabel);

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolQueueTaskDispatcherTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolQueueTaskDispatcherTest.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 hughsaunders.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.rackspace.jenkins_nodepool;
+
+import hudson.model.Node;
+import hudson.model.Slave;
+import hudson.model.queue.CauseOfBlockage;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author hughsaunders
+ */
+public class NodePoolQueueTaskDispatcherTest {
+
+    Mocks m;
+
+    public NodePoolQueueTaskDispatcherTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+        m = new Mocks();
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test that when a matching item and node are given, null is returned.
+     */
+    @Test
+    public void testCanTakeMatch() {
+        NodePoolQueueTaskDispatcher instance = new NodePoolQueueTaskDispatcher();
+        CauseOfBlockage expResult = null;
+        CauseOfBlockage result = instance.canTake(m.nps, m.task);
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test that a nodepool node can't take a task it wasn't
+     * created for.
+     */
+    @Test
+    public void testCanTakeMisMatch(){
+        NodePoolQueueTaskDispatcher instance = new NodePoolQueueTaskDispatcher();
+        // new run object so the tasks's run doesn't match
+        // the node's run. This should cause canTake to return a CoB
+        when(m.npj.getRun()).thenReturn(mock(WorkflowRun.class));
+        CauseOfBlockage result = instance.canTake(m.nps, m.task);
+        assertTrue(result instanceof NodePoolQueueTaskDispatcher.NodeCreatedForAnotherBuildCauseOfBlockage);
+    }
+
+    /**
+     * Test that when the node supplied is not a nodepool node,
+     * no blockage is returned even if the Runs don't match
+     */
+    @Test
+    public void testCanTakeIgnoreNonNodePool(){
+        NodePoolQueueTaskDispatcher instance = new NodePoolQueueTaskDispatcher();
+        // Mock node doesn't have a run object, but test
+        // should still pass as canTake should return null
+        // after checking the class of the node object.
+        Node node = mock(Slave.class);
+        CauseOfBlockage result = instance.canTake(node, m.task);
+        assertEquals(result, null);
+
+    }
+
+}

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolRequestStateWatcherTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolRequestStateWatcherTest.java
@@ -3,19 +3,17 @@ package com.rackspace.jenkins_nodepool;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingServer;
 import org.junit.*;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
-
 import static org.junit.Assert.*;
 
 /**
@@ -34,8 +32,10 @@ public class NodePoolRequestStateWatcherTest {
     private static CuratorFramework zkCli;
     private final static Gson gson = new Gson();
     private static final int DEFAULT_TEST_TIMEOUT_SEC = 30;
+    private Mocks m;
 
     public NodePoolRequestStateWatcherTest() {
+        m = new Mocks();
     }
 
     @BeforeClass
@@ -70,6 +70,7 @@ public class NodePoolRequestStateWatcherTest {
 
     @Before
     public void before() {
+        m = new Mocks();
     }
 
     @After
@@ -93,7 +94,7 @@ public class NodePoolRequestStateWatcherTest {
             timer.schedule(getTimerTask(zpath, NodePoolState.FULFILLED), 5000L);
 
             final NodePoolRequestStateWatcher watcher = new NodePoolRequestStateWatcher(
-                    zkCli, zpath, NodePoolState.FULFILLED);
+                    zkCli, zpath, NodePoolState.FULFILLED, m.npj);
 
             log.fine("Waiting for " + DEFAULT_TEST_TIMEOUT_SEC + " seconds max for the watcher...");
             watcher.waitUntilDone(DEFAULT_TEST_TIMEOUT_SEC, TimeUnit.SECONDS);
@@ -126,7 +127,7 @@ public class NodePoolRequestStateWatcherTest {
             timer.schedule(getTimerTask(zpath, NodePoolState.PENDING), 5000L);
 
             final NodePoolRequestStateWatcher watcher = new NodePoolRequestStateWatcher(
-                    zkCli, zpath, NodePoolState.FULFILLED);
+                    zkCli, zpath, NodePoolState.FULFILLED, m.npj);
 
             log.fine("Waiting for " + DEFAULT_TEST_TIMEOUT_SEC + " seconds max for the watcher...");
             try {
@@ -166,7 +167,7 @@ public class NodePoolRequestStateWatcherTest {
 
             // We hope to get a fulfilled end-state, but we won't for this test
             final NodePoolRequestStateWatcher watcher = new NodePoolRequestStateWatcher(
-                    zkCli, zpath, NodePoolState.FULFILLED);
+                    zkCli, zpath, NodePoolState.FULFILLED, m.npj);
 
             log.fine("Waiting for " + DEFAULT_TEST_TIMEOUT_SEC + " seconds max for the watcher...");
             try {
@@ -202,7 +203,7 @@ public class NodePoolRequestStateWatcherTest {
 
             // We hope to get a fulfilled end-state, but we won't for this test
             final NodePoolRequestStateWatcher watcher = new NodePoolRequestStateWatcher(
-                    zkCli, zpath, NodePoolState.FULFILLED);
+                    zkCli, zpath, NodePoolState.FULFILLED, m.npj);
 
             log.fine("Waiting for " + DEFAULT_TEST_TIMEOUT_SEC + " seconds max for the watcher...");
             try {
@@ -237,7 +238,7 @@ public class NodePoolRequestStateWatcherTest {
 
             // Set a watch - this time with a short timeout so that we will...timeout early
             final NodePoolRequestStateWatcher watcher = new NodePoolRequestStateWatcher(
-                    zkCli, zpath, NodePoolState.FULFILLED);
+                    zkCli, zpath, NodePoolState.FULFILLED, m.npj);
 
             final int timeoutInSeconds = 5;
             log.fine("Waiting for " + timeoutInSeconds + " seconds max for the watcher...");
@@ -282,7 +283,7 @@ public class NodePoolRequestStateWatcherTest {
             timer3.schedule(getTimerTask(zpath, NodePoolState.FULFILLED), 5000L);
 
             final NodePoolRequestStateWatcher watcher = new NodePoolRequestStateWatcher(
-                    zkCli, zpath, NodePoolState.FULFILLED);
+                    zkCli, zpath, NodePoolState.FULFILLED, m.npj);
 
             log.fine("Waiting for " + DEFAULT_TEST_TIMEOUT_SEC + " seconds max for the watcher...");
             watcher.waitUntilDone(DEFAULT_TEST_TIMEOUT_SEC, TimeUnit.SECONDS);

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodePoolsTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodePoolsTest.java
@@ -141,9 +141,9 @@ public class NodePoolsTest {
     @Test
     public void testProvisionNode() throws Exception {
         nps.getNodePools().add(m.np);
-        nps.provisionNode(m.label, m.task, 0);
+        nps.provisionNode(m.label, m.task, m.qID);
 
-        final NodePoolJob job = new NodePoolJob(m.label, m.task, 0);
+        final NodePoolJob job = new NodePoolJob(m.label, m.task, m.qID);
         verify(m.np).provisionNode(job);
     }
 

--- a/src/test/java/com/rackspace/jenkins_nodepool/NodeRequestTest.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/NodeRequestTest.java
@@ -24,9 +24,6 @@
 package com.rackspace.jenkins_nodepool;
 
 import com.google.gson.Gson;
-import org.apache.zookeeper.data.Stat;
-import org.junit.*;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +31,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
+import org.apache.zookeeper.data.Stat;
+import org.junit.*;
 import static org.junit.Assert.*;
 
 /**
@@ -62,7 +60,7 @@ public class NodeRequestTest {
     @Before
     public void setUp() throws Exception {
         m = new Mocks();
-        nr = new NodeRequest(m.np, m.task);
+        nr = new NodeRequest(m.np, m.npj);
     }
 
     @After
@@ -73,7 +71,7 @@ public class NodeRequestTest {
     @Test
     public void TestSerialisation() {
         try {
-            NodeRequest nr = new NodeRequest(m.np, m.task);
+            NodeRequest nr = new NodeRequest(m.np, m.npj);
             String json = nr.toString();
 
             LOG.fine("TestSerialisation json string: " + json);

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
* Reduces compatibility to Workflow / Pipeline jobs only.
    * Adds dependency on workflow-aggregator plugin (Which brings in all
      related plugins)
* Adds IP address and expiry time to information printed to
  job console when a node is held
* Links all node pool related objects to the Run that they were created
  for, for most ojbects this is via a NodePoolRun object that has a reference
  to A run.
  * NodeRequest: Adds a NodePoolJob field, also stores the
        Run's externalizable id in the node requests's zookeeper data
        under the key 'build_id'
  * NodePoolNode: Adds a NodePoolJob field, also stores the
        Run's extrnalizable id (jobname#buildnumber) in the node's
        zookeeper data under the key 'build_id'
  * KazooLock: Adds NodePoolJob field, adds Run's externalizable id
        to the requestor string thats stored in zookeeper. It used
        to be jenkins, now its jenkins_jobname#buildnumber
  * NodePoolSlave: Adds a NodePoolJob field
  * NodePoolComputer: Adds a NodePoolJob field

* Janitor is updated to check if the Run associated with each node
  is still executing before cleaning up nodes. Janitorial checks
  for all the other object types that can now be linked to a run
  will be added in a future patch.

* Janitor logic is also simplified as we clean all nodes not associated
  with an active run. That covers other situations like an orphan
  Jenkins nodes that refers to a nodepool node that has already been
  cleaned up.

* Added log statement at the end of the Janitor thread callable, so
  that if the Janitor thread exits (shouldn't happen) then it can be
  detected in the log.

* Added checks at various points in the provisioning process to check
  That the related run is still executing. If not the node provisioning
  process is cancelled. This prevents unnecessary retries when a job
  is cancelled while it's waiting for a node. It also reduces the chances
  of unallocated nodes being attached to Jenkins. If that does happen
  the Janitor will remove them within 60s.

* Job link added to node configuration UI, so that a user can quickly
  get from a node to the build that created it.

* Changed retention strategy from ALWAYS to NOOP. This prevents
  infinite retries when attempting to ssh to a node. This means that
  if for some reason nodepool hands jenkins an inaccessible node,
  Jenkins will try twice, then discard and request a new node. that
  was always the intention, but the logic for it was never reached
  as the ALWAYS retention strategy would cause the launch to be retried
  indefinitely.

* Added some node related logging to the build log, so that progress
  of the node allocation project can be seen in the job.

* Added NodePoolQueueTaskDispatcher which ensures that a node only
  accepts tasks relating to the Build that it was created for.

* Removed job accounting from NodePoolComputer as there is now
  a clear 1:1 relationship between nodepool nodes and build/run, so
  its not necessary to keep track of all the jobs a nodepool computer
  has executed as there will only ever be one.

* Extended the NodePoolJob class to track more objects

* Added additional getJob query functions to NodePoolJobHistory for
  easily finding the relevant NodePoolJob object.

* Increased the number of NodePoolJob objects that NodePoolJobHistory
  stores

* Added test to NodePoolQueue listener that prevents builds that
  don't use a nodepool node from being entered into NodePoolJobHistory