### PR TITLE
RE-1971 Queue Management Refinements

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     build: .
     depends_on:
       - zookeeper
+    links:
+      - zookeeper
     volumes:
       - "~/.config:/root/.config"
     environment:

--- a/docker/nodepool.yaml
+++ b/docker/nodepool.yaml
@@ -1,5 +1,6 @@
 zookeeper-servers:
   - host: zookeeper
+    port: 2181
 
 labels:
   - name: debian

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJob.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolJob.java
@@ -142,20 +142,30 @@ public class NodePoolJob {
     }
 
     void failAttempt(Exception e) {
+        if(attempts.isEmpty()){
+            throw new IllegalStateException("Cannot mark attempt as failed if there are no attempts");
+        }
         logToBoth("Nodepool Node Requested Failed: "+e.toString());
         // mark current attempt as a failure
         getCurrentAttempt().fail(e);
     }
 
     void succeed() {
+        if(attempts.isEmpty()){
+            throw new IllegalStateException("Cannot mark attempt as successfull if there are no attempts");
+        }
         logToBoth("Nodepool Node Requested Succeded: "
                 +getCurrentAttempt().getRequest().toString());
         getCurrentAttempt().succeed();
     }
 
     private Attempt getCurrentAttempt() {
-        final int sz = attempts.size();
-        return attempts.get(sz - 1);
+        if (!attempts.isEmpty()){
+            final int sz = attempts.size();
+            return attempts.get(sz - 1);
+        }else{
+            return null;
+        }
     }
 
     public List<Attempt> getAttempts() {
@@ -164,14 +174,23 @@ public class NodePoolJob {
 
 
     public boolean isDone() {
+        if (attempts.isEmpty()){
+            return false;
+        }
         return getCurrentAttempt().isDone();
     }
 
     public boolean isSuccess() {
+        if (attempts.isEmpty()){
+            return false;
+        }
         return getCurrentAttempt().isSuccess();
     }
 
     public boolean isFailure() {
+        if(attempts.isEmpty()){
+            return false;
+        }
         return getCurrentAttempt().isFailure();
     }
 
@@ -196,15 +215,6 @@ public class NodePoolJob {
                 seconds / 3600,
                 (seconds % 3600) / 60,
                 seconds % 60);
-    }
-
-    /**
-     * Returns the underlying NodePool object assisted with the current request attempt.
-     *
-     * @return the underlying NodePool object assisted with the current request attempt.
-     */
-    public NodePool getNodePool() {
-        return getCurrentAttempt().getRequest().nodePool;
     }
 
     /**

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueListener.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolQueueListener.java
@@ -95,7 +95,8 @@ public class NodePoolQueueListener extends QueueListener {
                 try {
                     nodePools.provisionNode(label, wi.task, wi.getId());
                 } catch (Exception ex) {
-                    LOG.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+                    LOG.log(Level.SEVERE,
+                            "Exception thrown in provisioning thread, caught in onEnterWaiting: "+ex.getLocalizedMessage(), ex);
                 }
             });
         }

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolSSHLauncher.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolSSHLauncher.java
@@ -220,7 +220,11 @@ public class NodePoolSSHLauncher extends ComputerLauncher {
                                 throw e;
                             }
                         }
-                        Thread.sleep(TimeUnit.SECONDS.toMillis(retryWaitTimeSeconds*(i+1)));
+                        try {
+                            Thread.sleep(TimeUnit.SECONDS.toMillis(retryWaitTimeSeconds*(i+1)));
+                        }catch (InterruptedException e){
+                            // meh
+                        }
                     }
 
                     // The java binary _should_ be in the path now
@@ -400,7 +404,11 @@ public class NodePoolSSHLauncher extends ComputerLauncher {
                     throw ioexception;
                 }
             }
-            Thread.sleep(TimeUnit.SECONDS.toMillis(retryWaitTimeSeconds));
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(retryWaitTimeSeconds));
+            } catch (InterruptedException ex){
+                Thread.currentThread().interrupt();
+            }
         }
 
         StandardUsernameCredentials credentials = getCredentials();

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolSlave.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolSlave.java
@@ -135,15 +135,19 @@ public class NodePoolSlave extends Slave {
                         "", //suffixStartSlaveCmd
                         60, //launchTimeoutSeconds
                          2, //maxNumRetries keep this low, as the whole provision process is retried (request, accept, launch)
-                        10, //retryWaitTime
+                        60, //retryWaitTime. This should relate to launchTimeout in NodePool.java
                         new ManuallyProvidedKeyVerificationStrategy(nodePoolNode.getHostKey())
                 ),
                 RetentionStrategy.NOOP, //retentionStrategy
                 new ArrayList() //nodeProperties
         );
         this.nodePoolJob =  npj;
+        if(this.nodePoolJob == null){
+            LOG.warning("NodePoolJob null in NodePoolSlave constructor");
+        } else {
+            this.nodePoolJob.logToBoth("NodePoolSlave created: "+ this.getDisplayName());
+        }
         this.nodePoolNode = nodePoolNode;
-        this.nodePoolJob.logToBoth("NodePoolSlave created: "+ this.getDisplayName());
     }
 
     /**

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/config.jelly
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/config.jelly
@@ -5,7 +5,7 @@
             <f:textbox/>
         </f:entry>
         <f:validateButton title="Test ZooKeeper Connection"
-                          progress="Testing.." 
+                          progress="Testing.."
                           method="testZooKeeperConnection"
                           with="connectionString">
         </f:validateButton>
@@ -15,10 +15,16 @@
         <f:entry title="Label Prefix" field="labelPrefix">
             <f:textbox default="nodepool-"></f:textbox>
         </f:entry>
-        <f:entry title="Request Timeout Seconds" field="requestTimeout">
-            <f:number default="500"></f:number>
-        </f:entry>
         <f:advanced>
+            <f:entry title="Install Timeout Seconds" field="installTimeout">
+                <f:number default="240"></f:number>
+            </f:entry>
+            <f:entry title="Request Timeout Seconds" field="requestTimeout">
+                <f:number default="500"></f:number>
+            </f:entry>
+            <f:entry title="Request Attempts" field="maxAttempts">
+                <f:number default="3"></f:number>
+            </f:entry>
             <f:entry title="ZooKeeper Root" field="zooKeeperRoot">
                 <f:textbox default="nodepool"></f:textbox>
             </f:entry>
@@ -45,4 +51,4 @@
                 <f:textbox name="jdkHome" value="${jdkHome}"/>
             </f:entry>
         </f:advanced>
-</j:jelly>  
+</j:jelly>

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-installTimeout.html
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-installTimeout.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+	Timeout in seconds for connecting to a node via SSH and completing the JRE installation
+	if required. (Nodes that already have a suitable JVM skip the installation step)
+</div>

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-maxAttempts.html
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-maxAttempts.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+	Each time a Jenkins build is allocated to a nodepool label, the plugin will make
+	up to this number of requests to nodepool for a node. If a node has not been
+	successfully provisioned after this number of attempts, the build will fail.
+</div>

--- a/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-requestTimeout.html
+++ b/src/main/resources/com/rackspace/jenkins_nodepool/NodePool/help-requestTimeout.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+The MIT License
+
+Copyright 2018 Rackspace.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+	Timeout in seconds for nodepool to fulfil a node request.
+	If nodepool doesn't have any ready nodes, it will have to create a new
+	instance to fulfil the request, so this should be at least long enough
+	for the provider to provision an instance. Note that if nodepool
+	is at quota, and no nodes are released while the request is waiting,
+	the request will be marked as failed after this amount of time.
+</div>

--- a/src/test/java/com/rackspace/jenkins_nodepool/Mocks.java
+++ b/src/test/java/com/rackspace/jenkins_nodepool/Mocks.java
@@ -85,6 +85,8 @@ public class Mocks {
     NodeRequest nr;
     List<NodePoolNode> allocatedNodes;
     Integer requestTimeout;
+    Integer installTimeout;
+    Integer maxAttempts;
     String holdUntilRoot;
     String jdkInstallationScript;
     String jdkHome;
@@ -100,8 +102,11 @@ public class Mocks {
     List<Attempt> attemptListSuccess;
     Attempt attemptSuccess;
 
+
     public Mocks() {
         requestTimeout = 30;
+        installTimeout = 60;
+        maxAttempts = 3;
         requestor = "unittests";
         priority = "001";
         labelPrefix = "nodepool-";


### PR DESCRIPTION
* Fix bug where a request is removed from Jenkins without being
  removed from Zookeeper

* Add Request Timeout and Request Attempts config options
  to the UI

* Add cleanup lock to ensure post-build cleanup and Janitor cleanup
  don't run concurrently

* Add delay when cleaning a node to wait for other processses
  to finish communicating with it.

* Delete nodes from a pool thread rather than the main Janitor thread
  This prevents waits from blocking the main Janitor thread.

* Add initial state check to NodePoolRequestStateWatcher to catch
  the situation where the request is already in the required state
  when the watcher is created. This may have caused an infinite
  wait previously as we're waiting for an event thats already
  happened.

* Override disconnect method in NodePoolComputer so that the cleanup
  lock can be obtained for disconnection.

* Fix bug in NodePool.attemptProvision2 where we wait for a node
  to come online, but don't correctly detect this condition so
  carry on waiting.

* Remove nodes created by failed provisioning attempts.
  Previously these nodes would linger until the build that
  requested them completed, then get cleaned up by the Janitor.
  Now we attempt to remove them when an exception is caught in
  the provisioning process.