### PR TITLE
RE-2230 Cleanup Deadlock

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolComputer.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolComputer.java
@@ -29,6 +29,8 @@ import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -96,8 +98,9 @@ public class NodePoolComputer extends SlaveComputer {
             // Call get to block until disconnection
             // has been executed, to ensure execution
             // happens while cleanupLock is held.
-            result.get();
-        } catch (InterruptedException | ExecutionException ex) {
+            // Timeout added so that the cleanupLock is not held indefinitely.
+            result.get(2, TimeUnit.MINUTES);
+        } catch (InterruptedException | ExecutionException | TimeoutException ex) {
             Logger.getLogger(NodePoolComputer.class.getName()).log(Level.SEVERE, null, ex);
         } finally {
             cleanupLock.unlock();


### PR DESCRIPTION
The Janitor thread initiates a clean every 60s. If a node is found that
needs to be cleaned up, a thread is created to clean it up. This thread
waits for the cleanup lock before proceeding. Once the lock is acquired
it does the cleanup, which invovles creating another thread.

The problem is that these cleanup threads can build up, especially
when there are many nodes to remove. If they build up to the near the
thread limit, then deadlock can occur as one thread has the lock, but
it can't create a thread to complete it's task as there are too many
other threads waiting for the lock.

This commit also adds a timeout to a blocking call in
NodepoolComputer.disconnect so that it can't hold the cleanup lock
indefinitely.