### PR TITLE
RE-2230 Disable Label Finder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>nodepool-agents</artifactId>
-    <version>0.0.20-SNAPSHOT</version>
+    <version>0.0.20</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Original -->
@@ -54,7 +54,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>HEAD</tag>
+        <tag>nodepool-agents-0.0.20</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>nodepool-agents</artifactId>
-    <version>0.0.20</version>
+    <version>0.0.21-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Original -->
@@ -54,7 +54,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>nodepool-agents-0.0.20</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePoolLabelFinder.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePoolLabelFinder.java
@@ -42,7 +42,14 @@ public class NodePoolLabelFinder extends LabelFinder {
     @Override
     public Collection<LabelAtom> findLabels(Node node) {
         Set<LabelAtom> labels = new HashSet<>();
+        return labels;
 
+        // RE-2230. This has been disabled, because the ZK exists call can block
+        // The main jenkins Queue lock is acquired before calling this function
+        // when a node is deleted, so if the ZK call blocks, the Queue lock
+        // is held, and new builds can't proceed out of the queue.
+
+        /*
         if(node instanceof NodePoolSlave){
             NodePoolSlave nps = (NodePoolSlave) node;
             NodePoolNode npn = nps.getNodePoolNode();
@@ -55,6 +62,7 @@ public class NodePoolLabelFinder extends LabelFinder {
         }
 
         return labels;
+        */
     }
 
 }


### PR DESCRIPTION
Label finder is disabled to prevent the Queue lock being held for long
periods of time. This can happen because the Queue lock is acquired
before calling findLables (when a node is deleted), and findLabels
can block.
cf355e8