### PR TITLE
RE-2397 Remove Nodepools.cleanupLock

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePools.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePools.java
@@ -58,16 +58,6 @@ public class NodePools extends GlobalConfiguration implements Iterable<NodePool>
         return GlobalConfiguration.all().get(NodePools.class);
     }
 
-    /**
-     * Lock that controls cleanup.
-     * We cleanup nodes in the Janitor thread and whenever
-     * a job completes. This lock will be acquired by
-     * either thread when performing cleanup to prevent
-     * races
-     */
-    private transient Lock cleanupLock;
-
-
     private List<NodePool> nodePools;
 
     // track job history - do not persist across restarts
@@ -87,9 +77,6 @@ public class NodePools extends GlobalConfiguration implements Iterable<NodePool>
     private void initTransients() {
         if (nodePools == null) {
             nodePools = new ArrayList<NodePool>();
-        }
-        if (cleanupLock == null){
-            cleanupLock = new ReentrantLock();
         }
     }
 
@@ -126,10 +113,6 @@ public class NodePools extends GlobalConfiguration implements Iterable<NodePool>
 
     public List<NodePool> getNodePools() {
         return nodePools;
-    }
-
-    public Lock getCleanupLock() {
-        return cleanupLock;
     }
 
     @Override


### PR DESCRIPTION
This lock is acquired inconsistently leading to a deadlock where
one thread holds the Queue lock but needs cleanup lock, and another
holads cleanup but needs the Queue lock.

After considering the code and the consequences, I've decided its best
to remove the cleanup lock. This may result in some KazooLock exceptions
in the logs if two threads attempt to release the same node, but thats
better than causing a Jenkins master hang due to deadlock. This is the
second deadlock bug thats been found relating to this cleanup lock and
I don't want to discover any more.